### PR TITLE
small changes

### DIFF
--- a/src/Box.js
+++ b/src/Box.js
@@ -6,6 +6,12 @@ import config from './config'
 import margin from './util/margin'
 import padding from './util/padding'
 
+const defaultBreakPoints = Object.keys(config.breakpoints)
+
+function w(n) {
+  return n ? (n / 12 * 100) + '%' : null
+}
+
 /**
  * Sets margin, padding, and width and works independently or as a child of <Flex />.
  */
@@ -19,16 +25,12 @@ const Box = ({
   ...props
 }, { reflexbox }) => {
 
-  const { breakpoints, scale } = { ...config, ...reflexbox }
-
-  function w(n) {
-    return n ? (n / 12 * 100) + '%' : null
-  }
+  const { breakpoints, scale } = reflexbox ? { ...config, ...reflexbox } : config
 
   let width = w(col)
 
   if (typeof window !== 'undefined') {
-    Object.keys(breakpoints).forEach(key => {
+    (reflexbox ? Object.keys(breakpoints) : defaultBreakPoints).forEach(key => {
       if (props[key] && window.matchMedia(breakpoints[key]).matches) {
         width = w(props[key]) || width
       }
@@ -73,8 +75,9 @@ Box.propTypes = {
 
   /** Passes in a custom element or component */
   is: React.PropTypes.oneOfType([
-    React.PropTypes.element,
-    React.PropTypes.node
+    React.PropTypes.string,
+    React.PropTypes.object,
+    React.PropTypes.func
   ]),
 
   /** Sets padding based on a scale of 0–4 */
@@ -116,4 +119,3 @@ Box.contextTypes = {
 }
 
 export default Box
-

--- a/src/Flex.js
+++ b/src/Flex.js
@@ -4,6 +4,8 @@ import assign from 'object-assign'
 import Base from './Base'
 import config from './config'
 
+const defaultBreakPoints = Object.keys(config.breakpoints)
+
 /**
  * Creates a flexbox context to control layout of children.
  */
@@ -18,15 +20,16 @@ const Flex = ({
 }, { reflexbox }) => {
 
   let display = 'flex'
-  const { breakpoints } = { ...config, ...reflexbox }
+  const { breakpoints } = reflexbox ? { ...config, ...reflexbox } : config
 
   if (typeof window !== 'undefined') {
-    Object.keys(breakpoints).forEach(key => {
-      if (Object.keys(props).indexOf(key) > -1) {
+    const b = reflexbox ? Object.keys(breakpoints) : defaultBreakPoints
+    b.forEach(key => {
+      if (key in props) {
         display = 'block'
       }
     })
-    Object.keys(breakpoints).forEach(key => {
+    b.forEach(key => {
       if (props[key] && window.matchMedia(breakpoints[key]).matches) {
         display = 'flex'
       }
@@ -77,8 +80,9 @@ Flex.propTypes = {
   auto: React.PropTypes.bool,
   /** Passes in a custom element or component */
   is: React.PropTypes.oneOfType([
-    React.PropTypes.element,
-    React.PropTypes.node
+    React.PropTypes.string,
+    React.PropTypes.object,
+    React.PropTypes.func
   ])
 }
 
@@ -90,4 +94,3 @@ Flex.contextTypes = {
 }
 
 export default Flex
-


### PR DESCRIPTION
- fix `is` propType for Flex and Box (copied from Base)
- move `w` function definition outside of Box render method
- replaced `Object.keys(props).indexOf(key)` check with `in` check
  - safe unless someone decides to define custom breakpoints with one of the following names ("toString", "toLocaleString", "valueOf", "hasOwnProperty", "propertyIsEnumerable", "isPrototypeOf", "\__defineGetter__", "\__defineSetter__", "\__lookupGetter__", "\__lookupSetter__", "\__proto__", "constructor"), in which case the existing code would misbehave as well
- faster path for when reflexbox context is not defined
  - avoid calling Object.keys(breakpoints) on every render
  - avoid call to Object.assign on every render