### PR TITLE
Safari 8 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "webpack-dev-server": "^1.12.0"
   },
   "dependencies": {
-    "object-assign": "^4.0.1",
-    "react-prefixr": "^0.1.0"
+    "inline-style-prefixer": "^1.0.4",
+    "object-assign": "^4.0.1"
   },
   "directories": {
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "webpack-dev-server": "^1.12.0"
   },
   "dependencies": {
-    "object-assign": "^4.0.1"
+    "object-assign": "^4.0.1",
+    "react-prefixr": "^0.1.0"
   },
   "directories": {
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "reflexbox",
-  "version": "1.1.2",
+  "name": "prefixed-reflexbox",
+  "version": "1.1.3",
   "description": "React flexbox layout and grid system",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Base.js
+++ b/src/Base.js
@@ -4,6 +4,7 @@ import assign from 'object-assign'
 import config from './config'
 import margin from './util/margin'
 import padding from './util/padding'
+import prefix from 'react-prefixr'
 
 const Base = ({
   style,
@@ -15,13 +16,13 @@ const Base = ({
 }, { reflexbox }) => {
   const { scale } = { ...config, ...reflexbox }
 
-  const sx = assign(
+  const sx = prefix(assign(
     { boxSizing: 'border-box' },
     style,
     _style,
     margin(props, scale),
     padding(props, scale)
-  )
+  ))
 
   const cx = className ? `${_className} ${className}` : _className
   const Component = is || 'div'

--- a/src/Base.js
+++ b/src/Base.js
@@ -17,15 +17,13 @@ const Base = ({
 }, { reflexbox }) => {
   const { scale } = { ...config, ...reflexbox }
 
-  const sx = assign(
+  const sx = prefixer.prefix(assign(
     { boxSizing: 'border-box' },
     style,
     _style,
     margin(props, scale),
     padding(props, scale)
-  )
-
-  console.log(prefixer.prefix(sx))
+  ))
 
   const cx = className ? `${_className} ${className}` : _className
   const Component = is || 'div'
@@ -33,7 +31,7 @@ const Base = ({
   return (
     <Component
       {...props}
-      style={prefixer.prefix(sx)}
+      style={sx}
       className={cx} />
   )
 }

--- a/src/Base.js
+++ b/src/Base.js
@@ -4,7 +4,8 @@ import assign from 'object-assign'
 import config from './config'
 import margin from './util/margin'
 import padding from './util/padding'
-import prefix from 'react-prefixr'
+import Prefixer from 'inline-style-prefixer'
+const prefixer = new Prefixer()
 
 const Base = ({
   style,
@@ -16,13 +17,15 @@ const Base = ({
 }, { reflexbox }) => {
   const { scale } = { ...config, ...reflexbox }
 
-  const sx = prefix(assign(
+  const sx = assign(
     { boxSizing: 'border-box' },
     style,
     _style,
     margin(props, scale),
     padding(props, scale)
-  ))
+  )
+
+  console.log(prefixer.prefix(sx))
 
   const cx = className ? `${_className} ${className}` : _className
   const Component = is || 'div'
@@ -30,7 +33,7 @@ const Base = ({
   return (
     <Component
       {...props}
-      style={sx}
+      style={prefixer.prefix(sx)}
       className={cx} />
   )
 }

--- a/test/Base.spec.js
+++ b/test/Base.spec.js
@@ -23,7 +23,7 @@ describe('Base', () => {
   })
 
   it('should have box-sizing by default', () => {
-    expect(style).toEqual({ boxSizing: 'border-box' })
+    expect(style).toInclude({ boxSizing: 'border-box' })
   })
 
   context('when setting style prop', () => {
@@ -34,7 +34,7 @@ describe('Base', () => {
     })
 
     it('should assign styles', () => {
-      expect(style).toEqual({ boxSizing: 'border-box', backgroundColor: 'tomato' })
+      expect(style).toInclude({ boxSizing: 'border-box', backgroundColor: 'tomato' })
     })
   })
 
@@ -50,7 +50,7 @@ describe('Base', () => {
     })
 
     it('should override style with _style', () => {
-      expect(style).toEqual({ boxSizing: 'border-box', backgroundColor: 'green' })
+      expect(style).toInclude({ boxSizing: 'border-box', backgroundColor: 'green' })
     })
   })
 


### PR DESCRIPTION
I don't expect that you'll merge this since it adds a new dependency. However this change makes reflexbox work in Safari 8 and possibly other legacy browsers. I need it for several products already in production that require support in Safari 8, so instead of keeping it to myself - I thought I'd send this over just in case you're interested.