### PR TITLE
fix relative links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ A component that creates a flexbox context to control layout of children.
 - `align` (string) Sets `align-item`. Accepted values: `stretch`, `center`, `baseline`, `flex-start`, `flex-end`
 - `justify` (string) Sets `justify-content`. Accepted values: `center`, `space-around`, `space-between`, `flex-start`, `flex-end`
 - `gutter` (number) Sets negative left and right margins to compensate for \<Box /\> padding.
-- `sm` (boolean) Sets `display: flex` only above the small breakpoint [*](breakpoint-props)
-- `md` (boolean) Sets `display: flex` only above the medium breakpoint [*](breakpoint-props)
-- `lg` (boolean) Sets `display: flex` only above the large breakpoint [*](breakpoint-props)
+- `sm` (boolean) Sets `display: flex` only above the small breakpoint [*](#-breakpoint-props)
+- `md` (boolean) Sets `display: flex` only above the medium breakpoint [*](#-breakpoint-props)
+- `lg` (boolean) Sets `display: flex` only above the large breakpoint [*](#-breakpoint-props)
 - `auto` (boolean) Sets `flex: 1 1 auto`
 
 ## \<Box /\>
@@ -60,31 +60,31 @@ A component that sets padding and width that works independently or as a child c
 - `align` (string) Sets `align-self` property
 - `order` (number) Sets `order` property
 - `col` (number) Sets width and flex-basis based on a twelve column grid.
-- `sm` (number) Sets width and flex-basis above the small breakpoint based on a twelve column grid. [*](breakpoint-props)
-- `md` (number) Sets width and flex-basis above the medium breakpoint based on a twelve column grid. [*](breakpoint-props)
-- `lg` (number) Sets width and flex-basis above the large breakpoint based on a twelve column grid. [*](breakpoint-props)
+- `sm` (number) Sets width and flex-basis above the small breakpoint based on a twelve column grid. [*](#-breakpoint-props)
+- `md` (number) Sets width and flex-basis above the medium breakpoint based on a twelve column grid. [*](#-breakpoint-props)
+- `lg` (number) Sets width and flex-basis above the large breakpoint based on a twelve column grid. [*](#-breakpoint-props)
 
 ## Shared Props
 
 Both \<Box /\> and \<Flex /\> accept the following props:
 
 - `is` (element or node) Passes in a custom element or component
-- `m` (number) Sets margin based on a scale from 0 – 4. [**](spacing-scale-props)
-- `mx` (number) Sets x-axis margin based on a scale from 0 – 4. [**](spacing-scale-props)
-- `my` (number) Sets y-axis margin based on a scale from 0 – 4. [**](spacing-scale-props)
-- `mt` (number) Sets margin-top based on a scale from 0 – 4. [**](spacing-scale-props)
-- `mb` (number) Sets margin-bottom based on a scale from 0 – 4. [**](spacing-scale-props)
-- `ml` (number) Sets margin-left based on a scale from 0 – 4. [**](spacing-scale-props)
-- `mr` (number) Sets margin-right based on a scale from 0 – 4. [**](spacing-scale-props)
-- `p` (number) Sets padding based on a scale from 0 – 4. [**](spacing-scale-props)
-- `px` (number) Sets x-axis padding based on a scale from 0 – 4. [**](spacing-scale-props)
-- `py` (number) Sets y-axis padding based on a scale from 0 – 4. [**](spacing-scale-props)
-- `pt` (number) Sets padding-top based on a scale from 0 – 4. [**](spacing-scale-props)
-- `pb` (number) Sets padding-bottom based on a scale from 0 – 4. [**](spacing-scale-props)
-- `pl` (number) Sets padding-left based on a scale from 0 – 4. [**](spacing-scale-props)
-- `pr` (number) Sets padding-right based on a scale from 0 – 4. [**](spacing-scale-props)
-- `style` (object) Assigns styles to the component [***](#style-and-classname-props)
-- `className` (string) Adds a class to the component [***](#style-and-classname-props)
+- `m` (number) Sets margin based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `mx` (number) Sets x-axis margin based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `my` (number) Sets y-axis margin based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `mt` (number) Sets margin-top based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `mb` (number) Sets margin-bottom based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `ml` (number) Sets margin-left based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `mr` (number) Sets margin-right based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `p` (number) Sets padding based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `px` (number) Sets x-axis padding based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `py` (number) Sets y-axis padding based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `pt` (number) Sets padding-top based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `pb` (number) Sets padding-bottom based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `pl` (number) Sets padding-left based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `pr` (number) Sets padding-right based on a scale from 0 – 4. [**](#-spacing-scale-props)
+- `style` (object) Assigns styles to the component [***](#-style-and-classname-props)
+- `className` (string) Adds a class to the component [***](#-style-and-classname-props)
 
 #### * Breakpoint props
 
@@ -172,4 +172,3 @@ npm test
 ```
 
 [MIT License](.github/LICENSE.md)
-


### PR DESCRIPTION
I noticed some of these links would 404 when I clicked on them, so I fixed the fragment identifiers to work on Github