### PR TITLE
re-use MediaQueryList objects (the things returned by window.matchMedia)

### DIFF
--- a/src/withReflex.js
+++ b/src/withReflex.js
@@ -12,6 +12,16 @@ const getWidth = (props) => (matches = []) => {
 
 const bgGrid = ruled()
 
+const QUERIES = Object.create(null)
+
+function getMatchMedia(query) {
+  if (!(query in QUERIES)) {
+    QUERIES[query] = window.matchMedia(query)
+  }
+
+  return QUERIES[query]
+}
+
 const withReflex = ({
   listen = true
 } = {}) => Comp => {
@@ -39,7 +49,7 @@ const withReflex = ({
         const matches = []
 
         for (let key in breakpoints) {
-          const match = window.matchMedia(breakpoints[key]).matches
+          const match = getMatchMedia(breakpoints[key]).matches
           if (match) {
             matches.push(key)
           }
@@ -55,7 +65,7 @@ const withReflex = ({
 
       if (listen) {
         for (let key in breakpoints) {
-          window.matchMedia(breakpoints[key]).addListener(this.match)
+          getMatchMedia(breakpoints[key]).addListener(this.match)
         }
       }
     }
@@ -63,7 +73,7 @@ const withReflex = ({
     componentWillUnmount () {
       const breakpoints = this.getBreakpoints()
       for (let key in breakpoints) {
-        window.matchMedia(breakpoints[key]).removeListener(this.match)
+        getMatchMedia(breakpoints[key]).removeListener(this.match)
       }
     }
 
@@ -157,4 +167,3 @@ const withReflex = ({
 }
 
 export default withReflex
-

--- a/src/withReflex.js
+++ b/src/withReflex.js
@@ -14,7 +14,7 @@ const bgGrid = ruled()
 
 const QUERIES = Object.create(null)
 
-function getMatchMedia(query) {
+function getMatchMedia (query) {
   if (!(query in QUERIES)) {
     QUERIES[query] = window.matchMedia(query)
   }

--- a/test/withReflex.js
+++ b/test/withReflex.js
@@ -11,8 +11,10 @@ let inner
 
 jsdom()
 
-window.matchMedia = () => ({
-  matches: false,
+let MATCHES = null
+
+window.matchMedia = query => ({
+  get matches () { return MATCHES ? MATCHES.test(query) : false },
   addListener: () => {},
   removeListener: () => {}
 })
@@ -75,11 +77,7 @@ test('renames `auto` prop', t => {
 })
 
 test('sm breakpoint', t => {
-  window.matchMedia = query => ({
-    matches: /40/.test(query),
-    addListener: () => {},
-    removeListener: () => {}
-  })
+  MATCHES = /40/
   wrapper = mount(<Box col={6} sm={3} md={2} lg={1} />)
   inner = wrapper.find('WrappedComponent')
 
@@ -90,11 +88,7 @@ test('sm breakpoint', t => {
 })
 
 test('md breakpoint', t => {
-  window.matchMedia = query => ({
-    matches: /52/.test(query),
-    addListener: () => {},
-    removeListener: () => {}
-  })
+  MATCHES = /52/
   wrapper = mount(<Box col={6} sm={3} md={2} lg={1} />)
   inner = wrapper.find('WrappedComponent')
 
@@ -105,11 +99,7 @@ test('md breakpoint', t => {
 })
 
 test('lg breakpoint', t => {
-  window.matchMedia = query => ({
-    matches: /64/.test(query),
-    addListener: () => {},
-    removeListener: () => {}
-  })
+  MATCHES = /64/
   wrapper = mount(<Box col={6} sm={3} md={2} lg={1} />)
   inner = wrapper.find('WrappedComponent')
 
@@ -120,11 +110,7 @@ test('lg breakpoint', t => {
 })
 
 test('custom breakpoints', t => {
-  window.matchMedia = query => ({
-    matches: /24/.test(query),
-    addListener: () => {},
-    removeListener: () => {}
-  })
+  MATCHES = /24/
   wrapper = mount(<Box col={6} sm={3} md={2} lg={1} />, {
     context: {
       reflexbox: {
@@ -158,4 +144,3 @@ test('accepts ref attribute', t => {
   wrapper = mount(<Root />)
   t.truthy(wrapper.ref('box'))
 })
-


### PR DESCRIPTION
part of #46

why this makes sense
- currently new MediaQueryList objects are created for:
  - inside each component every time `this.match` is called
  - for every component that uses `withReflex`
- `macthes` is a getter so it stays up-to-date without needing to re-create the object every time we use it
- re-creating these objects every time incurs:
  - the cost of garbage collecting all these objects
  - the cost of parsing the media query, per the spec it happens every time matchMedia is called
