### PR TITLE
React.PropTypes -> prop-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,12 @@ Values for the breakpoints can be configured with
 To configure reflexbox, add `childContextTypes` and `getChildContext` to a container component.
 
 ```js
+import PropTypes from 'prop-types'
+import React from 'react'
+
 class App extends React.Component {
   static childContextTypes = {
-    reflexbox: React.PropTypes.object
+    reflexbox: PropTypes.object
   }
 
   getChildContext () {

--- a/docs/components/Example.js
+++ b/docs/components/Example.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import toJsx from 'react-element-to-jsx-string'
 import { Box } from '../..'
@@ -11,7 +12,7 @@ const Example = ({ example, ...props }) => (
 )
 
 Example.propTypes = {
-  example: React.PropTypes.node
+  example: PropTypes.node
 }
 
 export default Example

--- a/package.json
+++ b/package.json
@@ -40,11 +40,15 @@
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.3.0",
     "react-element-to-jsx-string": "^3.2.0",
+    "react-test-renderer": "^15.5.4",
     "standard": "^7.1.2",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "robox": "^1.0.0-beta.8",
     "ruled": "^1.0.1"
   },

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import withReflex from './withReflex'
 
@@ -20,7 +21,7 @@ const Grid = ({
 }
 
 Grid.propTypes = {
-  align: React.PropTypes.oneOf([
+  align: PropTypes.oneOf([
     'top',
     'middle',
     'bottom',

--- a/src/withReflex.js
+++ b/src/withReflex.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Robox from 'robox'
 import ruled from 'ruled'
@@ -126,39 +127,39 @@ const withReflex = ({
   }
 
   ReflexWrap.contextTypes = {
-    reflexbox: React.PropTypes.shape({
-      breakpoints: React.PropTypes.object,
-      debug: React.PropTypes.bool
+    reflexbox: PropTypes.shape({
+      breakpoints: PropTypes.object,
+      debug: PropTypes.bool
     })
   }
 
   ReflexWrap.propTypes = {
-    flex: React.PropTypes.bool,
-    wrap: React.PropTypes.bool,
-    flexColumn: React.PropTypes.bool,
-    column: React.PropTypes.bool,
-    align: React.PropTypes.oneOf([
+    flex: PropTypes.bool,
+    wrap: PropTypes.bool,
+    flexColumn: PropTypes.bool,
+    column: PropTypes.bool,
+    align: PropTypes.oneOf([
       'stretch',
       'center',
       'baseline',
       'flex-start',
       'flex-end'
     ]),
-    justify: React.PropTypes.oneOf([
+    justify: PropTypes.oneOf([
       'center',
       'space-around',
       'space-between',
       'flex-start',
       'flex-end'
     ]),
-    flexAuto: React.PropTypes.bool,
-    auto: React.PropTypes.bool,
-    flexNone: React.PropTypes.bool,
-    order: React.PropTypes.number,
-    col: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-    sm: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-    md: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-    lg: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    flexAuto: PropTypes.bool,
+    auto: PropTypes.bool,
+    flexNone: PropTypes.bool,
+    order: PropTypes.number,
+    col: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    sm: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    md: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    lg: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
     is: (props, propName, componentName) => {
       if (props[propName]) {
         return new Error(


### PR DESCRIPTION
v15.5.0 of react adds a [deprecation warning for `React.PropTypes`](https://facebook.github.io/react/blog/#migrating-from-react.proptypes).

Instead we're encouraged to install the separate `prop-types` package and use PropTypes from there.

```js
import PropTypes from 'prop-types';
```

This PR adds upgrades the version of react in the `devDependencies`, adds `prop-types` to the deps, and updates all components to use the `prop-types` package instead of `React.PropTypes`.