### PR TITLE
Making it compatible with other grid columns systems

### DIFF
--- a/src/withReflex.js
+++ b/src/withReflex.js
@@ -155,10 +155,10 @@ const withReflex = ({
     auto: React.PropTypes.bool,
     flexNone: React.PropTypes.bool,
     order: React.PropTypes.number,
-    col: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-    sm: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-    md: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-    lg: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    col: React.PropTypes.number,
+    sm: React.PropTypes.number,
+    md: React.PropTypes.number,
+    lg: React.PropTypes.number,
     is: (props, propName, componentName) => {
       if (props[propName]) {
         return new Error(


### PR DESCRIPTION
First of: thank you so much for Reflexbox! I love this project.

Since Robox allows [to configure the number of grid columns](https://github.com/jxnblk/robox#configuration), it would be nice if Reflexbox didn't restrict them to 12.

I'm sending this PR because I'm currently converting a project that was done in a 16 grid system to React and I'm getting warning messages that don't apply to me because I've changed the number of grid columns to 16 through the context configuration.